### PR TITLE
Mvp0.1.0a4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Planned
 - Custom HTML report themes
 
+## [0.0.0a4] - 2025-08-19
+
+### Changed
+- Revised versioning approach: switched to 0.0.0aN pre-release tag pattern to better reflect early, unstable iteration cadence before first public minor (0.1.0).
+
+### Added
+- Display of pytest parametrization values in HTML report: each parametrized test invocation now shows its parameters inline in the test title (e.g. `Test with parametrize [id=2]`), improving traceability when multiple variants run.
+
+### Internal
+- No functional logic changes besides exposing collected `callspec.params` in results payload.
+
 ## [0.0.3a] - 2025-08-19
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sdk-pytest-checkmate"
-version = "0.0.3a"
+version = "0.1.0a4"
 description = "Pytest plugin for enriched HTML test reporting with steps, soft assertions, and data attachments"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/src/sdk_pytest_checkmate/plugin.py
+++ b/src/sdk_pytest_checkmate/plugin.py
@@ -521,6 +521,12 @@ def pytest_runtest_makereport(item, call):
             ],
             "epic": epic,
             "story": story,
+            "params": {
+                k: repr(v)
+                for k, v in getattr(
+                    getattr(item, "callspec", None), "params", {}
+                ).items()
+            },
         }
     )
 
@@ -882,13 +888,21 @@ def pytest_sessionfinish(session, exitstatus):
             idx = row_index
             row_index += 1
             short = esc(r.get("short", ""))
+            params = r.get("params") or {}
+            if params:
+                inline_params = ", ".join(
+                    f"{esc(str(k))}={esc(str(v))}" for k, v in params.items()
+                )
+                title_cell = f"{esc(r['title'])} [{inline_params}]"
+            else:
+                title_cell = esc(r["title"])
             timeline_html = format_timeline(
                 r.get("steps", []), r.get("soft_checks", []), r.get("data_reports", [])
             )
             errors_html = format_errors(r)
             expanded = f"<div class='detail-card status-{r['status']}'>{timeline_html}{errors_html}</div>"
             rows.append(
-                f"<tr class='status-{r['status']} main-row' data-group='{group_id}' data-status='{r['status']}' data-idx='{idx}'><td>{esc(r['title'])}</td>"
+                f"<tr class='status-{r['status']} main-row' data-group='{group_id}' data-status='{r['status']}' data-idx='{idx}'><td>{title_cell}</td>"
                 f"<td class='status-cell'><span class='st-{r['status']}'>{r['status']}</span></td><td>{r['duration']:.3f}</td><td class='details'>{short}</td></tr>"
                 f"<tr class='status-{r['status']} detail-row hidden manual-hidden' data-group='{group_id}' data-status='{r['status']}' data-idx='{idx}'><td colspan='4'>{expanded}</td></tr>"
             )


### PR DESCRIPTION
Changed
- Revised versioning approach: switched to 0.0.0aN pre-release tag pattern to better reflect early, unstable iteration cadence before first public minor (0.1.0).

Added
- Display of pytest parametrization values in HTML report: each parametrized test invocation now shows its parameters inline in the test title (e.g. `Test with parametrize [id=2]`), improving traceability when multiple variants run.